### PR TITLE
corrected socket exception... jetty couldnt find its config due to mi…

### DIFF
--- a/src/lcmap/aardvark/system.clj
+++ b/src/lcmap/aardvark/system.clj
@@ -89,4 +89,4 @@
    :db   (new-database cfg)
    :msg  (new-event cfg)
    :app  (component/using (new-app cfg) [:db :msg])
-   :server (component/using (jetty-server (:server cfg)) [:app])))
+   :http (component/using (jetty-server (:http cfg)) [:app])))


### PR DESCRIPTION
…snamed config section

Jetty couldn't find its config due to section named :http instead of :server.  Changed section and component name to :http.