### PR TITLE
Support retrieval of remote source data.

### DIFF
--- a/dev/resources/schema.setup.cql
+++ b/dev/resources/schema.setup.cql
@@ -5,11 +5,10 @@ CREATE TABLE IF NOT EXISTS lcmap_landsat_dev.sources (
     id text,
     uri text static,
     checksum text static,
-    state_at timestamp,
-    state_name text,
-    state_desc text,
-    ubid text,
-    PRIMARY KEY (id, state_at)
+    progress_at timestamp,
+    progress_name text,
+    progress_desc text,
+    PRIMARY KEY (id, progress_at)
 )
 WITH COMPRESSION = { 'sstable_compression' : 'LZ4Compressor' }
 AND  COMPACTION = { 'class' :  'LeveledCompactionStrategy' };

--- a/src/lcmap/aardvark/landsat.clj
+++ b/src/lcmap/aardvark/landsat.clj
@@ -30,7 +30,7 @@
 (defn put-source
   "Handle request for creating a source and produce a response."
   [source-id {params :params :as req}]
-  (let [source (merge {:id source-id :state_name "created"} params)]
+  (let [source (merge {:id source-id :progress_name "created"} params)]
     (or (some->> (source/validate source)
                  (assoc {:status 403} :body))
         (some->> (source/search source-id)

--- a/src/lcmap/aardvark/landsat.clj
+++ b/src/lcmap/aardvark/landsat.clj
@@ -131,8 +131,8 @@
    (context "/landsat" request
      (GET    "/" [] {:body nil})
      (ANY    "/" [] (allow "GET"))
-     (GET    "/source/:source-id" [source-id] (get-source source-id))
-     (PUT    "/source/:source-id" [source-id] (put-source source-id request))
+     (GET    "/source/:source-id{.+}" [source-id] (get-source source-id))
+     (PUT    "/source/:source-id{.+}" [source-id] (put-source source-id request))
      (GET    "/tiles" [] (get-tiles request))
      (GET    "/tile-spec" [] (get-tile-specs))
      (POST   "/tile-spec" [] (post-tile-spec request))

--- a/src/lcmap/aardvark/landsat.clj
+++ b/src/lcmap/aardvark/landsat.clj
@@ -132,7 +132,7 @@
      (GET    "/" [] {:body nil})
      (ANY    "/" [] (allow "GET"))
      (GET    "/source/:source-id" [source-id] (get-source source-id))
-     (PUT    "/source/:source-id" [source-id :as req] (put-source source-id request))
+     (PUT    "/source/:source-id" [source-id] (put-source source-id request))
      (GET    "/tiles" [] (get-tiles request))
      (GET    "/tile-spec" [] (get-tile-specs))
      (POST   "/tile-spec" [] (post-tile-spec request))

--- a/src/lcmap/aardvark/source.clj
+++ b/src/lcmap/aardvark/source.clj
@@ -73,6 +73,7 @@
    (let [source+ (merge source {:progress_at (time/now)
                                 :progress_name name
                                 :progress_desc desc})]
+     (log/infof "progress: %s %s - %s %s" (source :id) (source :uri) name desc)
      (insert source+)))
   ([source name]
    (progress source name nil)))

--- a/src/lcmap/aardvark/source.clj
+++ b/src/lcmap/aardvark/source.clj
@@ -21,9 +21,9 @@
   {:id schema/Str
    :uri schema/Str
    :checksum schema/Str
-   (schema/optional-key :state_at) schema/Any
-   (schema/optional-key :state_name) schema/Str
-   (schema/optional-key :state_desc) schema/Str})
+   (schema/optional-key :progress_at) schema/Any
+   (schema/optional-key :progress_name) schema/Str
+   (schema/optional-key :progress_desc) schema/Str})
 
 (defn search
   "Query DB for source."
@@ -61,18 +61,18 @@
 (defn insert-and-publish
   "Create a source and publish a message."
   [source]
-  (let [source+ (merge source {:state_at (time/now)
-                               :state_name "queue"})]
+  (let [source+ (merge source {:progress_at (time/now)
+                               :progress_name "queue"})]
     (io!
      (insert source+)
      (publish source+))))
 
-(defn activity
+(defn progress
   "Insert source row with state information."
   ([source name desc]
-   (let [source+ (merge source {:state_at (time/now)
-                                :state_name name
-                                :state_desc desc})]
+   (let [source+ (merge source {:progress_at (time/now)
+                                :progress_name name
+                                :progress_desc desc})]
      (insert source+)))
   ([source name]
-   (activity source name nil)))
+   (progress source name nil)))

--- a/src/lcmap/aardvark/tile.clj
+++ b/src/lcmap/aardvark/tile.clj
@@ -224,9 +224,9 @@
                         (remove fill?))
           [xs ys] (:data_shape band)
           tiles   (dataset->tiles tile-xf dataset xs ys)]
-      (progress source "band-start" (format "ubid: %s" (:ubid band)))
+      (progress source "band-start" (:ubid band))
       (dorun (pmap process-tile tiles))
-      (progress source "band-done" (format "ubid: %s" (:ubid band))))))
+      (progress source "band-done" (:ubid band)))))
 
 (defn process-scene
   "Saves all bands in dir referenced by path."

--- a/src/lcmap/aardvark/tile.clj
+++ b/src/lcmap/aardvark/tile.clj
@@ -234,6 +234,7 @@
    (let [band-xf   (comp (map +spec)
                          (map +fill)
                          (map +locate)
+                         (map (fn [band] (assoc band :source (:id source))))
                          (filter conforms?))]
      (dorun (pmap #(process-band % source) (scene->bands scene-dir band-xf)))
      :done)))

--- a/src/lcmap/aardvark/tile.clj
+++ b/src/lcmap/aardvark/tile.clj
@@ -255,23 +255,19 @@
         uncompress-file (fs/temp-file "lcmap-")
         unarchive-file  (fs/temp-dir  "lcmap-")]
     (try
+      (progress source "scene-start")
       (-> uri
           (util/download download-file)
           (util/verify checksum)
           (util/uncompress uncompress-file)
           (util/unarchive unarchive-file)
           (process-scene source))
+      (progress source "scene-finish")
       :done
       (finally
         (fs/delete-dir unarchive-file)
         (fs/delete uncompress-file)
         (fs/delete download-file)))))
-
-(comment "explain usage..."
-  (process {:id       "LE70460272000029"
-            :checksum "e1d2f9b28b1f55c13ee2a4b7c4fc52e7"
-            :uri      #_"http://localhost:3456/LE70460272000029-SC20160826120223.tar.gz"
-                      "file:/home/jmorton/Projects/lcmap/lcmap-landsat/data/ESPA/CONUS/ARD/LE70460272000029-SC20160826120223.tar.gz"}))
 
 ;;; Error handlers
 

--- a/src/lcmap/aardvark/tile_spec.clj
+++ b/src/lcmap/aardvark/tile_spec.clj
@@ -6,6 +6,7 @@
             [lcmap.aardvark.db :as db :refer [db-session]]
             [lcmap.aardvark.espa :as espa]
             [lcmap.aardvark.util :as util]
+            [me.raynes.fs :as fs]
             [mount.core :as mount :refer [defstate]]
             [qbits.alia :as alia]
             [qbits.hayt :as hayt]
@@ -100,11 +101,21 @@
 (defn process
   "Generate tile-specs from an ESPA archive"
   [{:keys [id checksum uri] :as source} opts]
-  (if (util/checksum! source)
-    (util/with-temp [dir uri]
-      (process-scene dir opts)
-      :done)
-    :failed))
+  (let [download-file   (fs/temp-file "lcmap-")
+        uncompress-file (fs/temp-file "lcmap-")
+        unarchive-file  (fs/temp-dir  "lcmap-")]
+    (try
+      (-> uri
+          (util/download download-file)
+          (util/verify checksum)
+          (util/uncompress uncompress-file)
+          (util/unarchive unarchive-file)
+          (process-scene opts))
+      :done
+      (finally
+        (fs/delete-dir unarchive-file)
+        (fs/delete uncompress-file)
+        (fs/delete download-file)))))
 
 (defn universal-band-ids
   "Returns ubids, which are a sequence of slash separated strings

--- a/test/lcmap/aardvark/util_test.clj
+++ b/test/lcmap/aardvark/util_test.clj
@@ -5,23 +5,13 @@
             [lcmap.aardvark.util :as util]
             [me.raynes.fs :as fs]))
 
-(deftest archive-tests
-  (testing "temporarily expanding .tar.xz"
-    (util/with-temp [dir (io/resource "data/test-archive.tar.xz")]
-      (is (fs/exists? dir))))
-  (testing "temporarily expanding .tar.gz"
-    (util/with-temp [dir (io/resource "data/test-archive.tar.gz")]
-      (is (fs/exists? dir))))
-  (testing "temporarily expanding .tar.bz2"
-    (util/with-temp [dir (io/resource "data/test-archive.tar.bz2")]
-      (is (fs/exists? dir)))))
-
 (deftest checksum-tests
   (testing "checksum matches"
-    (let [source {:uri (str (io/as-url (io/resource "data/test-archive.tar.gz")))
-                  :checksum "d2769e6390074dd52d88e82475a74d79"}]
-      (is (= (source :checksum) (util/checksum source)))))
+    (let [uri (str (io/as-url (io/resource "data/test-archive.tar.gz")))
+          checksum "d2769e6390074dd52d88e82475a74d79"]
+      (is (= checksum (util/checksum uri)))
+      (is (util/verify uri checksum))))
   (testing "checksum does not match"
-    (let [source {:uri (str (io/as-url (io/resource "data/test-archive.tar.gz")))
-                  :checksum "obviously-not-a-checksum"}]
-      (is (not= (source :checksum) (util/checksum source))))))
+    (let [uri (str (io/as-url (io/resource "data/test-archive.tar.gz")))
+          checksum "obviously-not-a-checksum"]
+      (is (not= checksum (util/checksum uri))))))

--- a/test/resources/schema.setup.cql
+++ b/test/resources/schema.setup.cql
@@ -6,11 +6,11 @@ CREATE TABLE IF NOT EXISTS lcmap_landsat_test.sources (
     id text,
     uri text static,
     checksum text static,
-    state_at timestamp,
-    state_name text,
-    state_desc text,
+    progress_at timestamp,
+    progress_name text,
+    progress_desc text,
     ubid text,
-    PRIMARY KEY (id, state_at)
+    PRIMARY KEY (id, progress_at)
 )
 WITH COMPRESSION = { 'sstable_compression' : 'LZ4Compressor' }
 AND  COMPACTION = { 'class' :  'LeveledCompactionStrategy' };


### PR DESCRIPTION
Workers will not have file-system access to source data. Even if they did, there is no way for the person submitting a source via the REST API to reasonably know the underlying file-system structure. Furthermore, this is brittle and prone to breakage if a docker container's volume fails to mount or the file system structure changes.

Even though sources can be submitted using any URI structure, including URLs with a file scheme, an operational system will expect HTTP scheme URLs. However, supporting both schemes makes working with local files in a sandbox environment easier, without introducing alternate execution paths or requiring a local HTTP server to provide sample data.

This change also sees related improvements to the way progress is reported. Progress is now logged at the info level. A schema change was also made to indicate that what was previously called "state" is actually just progress. The use of the word state can imply "finite-state-machine" to some, so using a different term seems like it will cause less confusion.