### PR TITLE
Revisit tile-spec creation.

### DIFF
--- a/dev/bin/tile-spec-post
+++ b/dev/bin/tile-spec-post
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 curl --verbose \
-     -H "Accept: application/json, */*" \
+     -H "Accept: application/json" \
      -H "Content-Type: application/json" \
      -X POST \
-     --data "@test/resources/data/sample-tile-specs.json" \
-     http://localhost:5678/landsat/tile-spec
+     --data "@tile-spec.json" \
+     http://localhost:5678/landsat/tile-specs

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,5 +1,6 @@
 (ns user
   (:require
+   [cheshire.core :as json]
    [clojure.tools.namespace.repl :refer [refresh refresh-all]]
    [clojure.java.io :as io]
    [clojure.edn :as edn]
@@ -20,12 +21,17 @@
          :uri (-> "ESPA/CONUS/ARD/LE70460272000029-SC20160826120223.tar.gz" io/resource io/as-url str)
          :checksum "e1d2f9b28b1f55c13ee2a4b7c4fc52e7"})
 
-(def tile-spec-opts {:data_shape [128 128]
+(def tile-spec-opts {:data_shape [100 100]
                      :name "conus"})
 
 (defn load-tile-spec []
   (tile-spec/process L5 tile-spec-opts)
   (tile-spec/process L7 tile-spec-opts))
+
+(defn dump-tile-spec [path]
+  (let [sorted (map (fn [kvs] (into (sorted-map) kvs)) (tile-spec/all))
+        output (json/generate-string {:pretty true})]
+    (spit path output)))
 
 (defn load-tiles []
   (tile/process L5)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -21,7 +21,7 @@
          :uri (-> "ESPA/CONUS/ARD/LE70460272000029-SC20160826120223.tar.gz" io/resource io/as-url str)
          :checksum "e1d2f9b28b1f55c13ee2a4b7c4fc52e7"})
 
-(def tile-spec-opts {:data_shape [100 100]
+(def tile-spec-opts {:data_shape [128 128]
                      :name "conus"})
 
 (defn load-tile-spec []

--- a/src/lcmap/aardvark/tile_spec.clj
+++ b/src/lcmap/aardvark/tile_spec.clj
@@ -53,16 +53,6 @@
                             (hayt/where params)
                             (hayt/allow-filtering)))))
 
-(defn insert
-  "Create tile-spec in DB."
-  [tile-spec]
-  (log/tracef "insert tile-spec: %s" tile-spec)
-  (->> (relevant tile-spec)
-       (hayt/values)
-       (hayt/insert :tile_specs)
-       (db/execute))
-  tile-spec)
-
 (def column-names [:name :ubid :wkt :satellite :instrument
                    :tile_x :tile_y :pixel_x :pixel_y :shift_x :shift_y
                    :band_product :band_category :band_name :band_long_name :band_short_name :band_spectrum
@@ -73,6 +63,16 @@
   "Use to eliminate potentially invalid columns names."
   [tile-spec]
   (select-keys tile-spec column-names))
+
+(defn insert
+  "Create tile-spec in DB."
+  [tile-spec]
+  (log/tracef "insert tile-spec: %s" tile-spec)
+  (->> (relevant tile-spec)
+       (hayt/values)
+       (hayt/insert :tile_specs)
+       (db/execute))
+  tile-spec)
 
 (defn dataset->spec
   "Deduce tile spec properties from band's dataset at file_path and band's data_shape"

--- a/src/lcmap/aardvark/tile_spec.clj
+++ b/src/lcmap/aardvark/tile_spec.clj
@@ -57,17 +57,17 @@
   "Create tile-spec in DB."
   [tile-spec]
   (log/tracef "insert tile-spec: %s" tile-spec)
-  (db/execute (hayt/insert :tile_specs
-                           (hayt/values tile-spec)))
+  (->> (relevant tile-spec)
+       (hayt/values)
+       (hayt/insert :tile_specs)
+       (db/execute))
   tile-spec)
-
-
-;;; Worker related
 
 (def column-names [:name :ubid :wkt :satellite :instrument
                    :tile_x :tile_y :pixel_x :pixel_y :shift_x :shift_y
                    :band_product :band_category :band_name :band_long_name :band_short_name :band_spectrum
-                   :data_fill :data_range :data_scale :data_type :data_units :data_shape :data_mask])
+                   :data_fill :data_range :data_scale :data_type
+                   :data_units :data_shape #_:data_mask])
 
 (defn relevant
   "Use to eliminate potentially invalid columns names."
@@ -91,7 +91,7 @@
        :pixel_x pixel_x
        :pixel_y pixel_y
        :tile_x tile_x
-       :tile_y tile_x
+       :tile_y tile_y
        :shift_x shift_x
        :shift_y shift_y})))
 


### PR DESCRIPTION
* Added a helper to dev/user.clj for producing a tile-spec.json that can be used with POST /landsat/tile-specs
* Side-step a problem creating data_mask from JSON; this will have to be revisited later. The current schema expects a data_mask map of int -> text, but JSON data is parsed as str -> str.