### PR TITLE
Provide dev function for loading tile-spec data

### DIFF
--- a/dev/bin/tile-spec-post
+++ b/dev/bin/tile-spec-post
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# PLEASE NOTE: This will not work until authorization is supported,
+# allowing unauthorized users to create or update tile-specs could
+# impair people's ability to retrieve tile data.
+
 curl --verbose \
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \

--- a/dev/bin/tile-spec-put
+++ b/dev/bin/tile-spec-put
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# PLEASE NOTE: This will not work until authorization is supported,
+# allowing unauthorized users to create or update tile-specs could
+# impair people's ability to retrieve tile data.
+
 curl --verbose \
      -H "Accept: application/json, */*" \
      -H "Content-Type: application/json" \

--- a/dev/seed.clj
+++ b/dev/seed.clj
@@ -1,28 +1,18 @@
 (ns seed
   "Provide recipes for seeding Cassandra (and Elasticsearch) with real-world
    congruent data."
-  (:require [lcmap.aardvark.tile-spec :as tile-spec]))
+  (:require [lcmap.aardvark.tile-spec :as tile-spec]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.pprint :refer [pprint]]))
 
 (comment
   "This will create tile-specs from real-world data that match what
    is seen production systems. The test data was created when the
    input format was not completely decided. Because this uses real
    data, it can take some time to download."
-  (let [spec-opts {:data_shape [100 100]
-                   :name "conus"}
-        L8 {:id "LC80410282013101-SC20161214141315"
-            :checksum "482333697999739445f2b10ac39b709d"
-            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12142016-124335-732/LC80410282013101-SC20161214141315.tar.gz"}
-        L7 {:id "LE070410282000138-SC20161230023316"
-            :checksum "b6a2c24eed48101546a2c178d64e3af5"
-            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204133-305/LE070410282000138-SC20161230023316.tar.gz"}
-        L5 {:id "LT050410281984118-SC20170103075240"
-            :checksum "b4f5e1245dcd8078d9981395bace8060"
-            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204932-763/LT050410281984118-SC20170103075240.tar.gz"}
-        L4 {:id "LT040410281982328-SC20170103075212"
-            :checksum "d65532771a5234176ebd125466e206ff"
-            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204932-763/LT040410281982328-SC20170103075212.tar.gz"}]
-    @(delay (tile-spec/process L8 spec-opts))
-    @(delay (tile-spec/process L7 spec-opts))
-    @(delay (tile-spec/process L5 spec-opts))
-    @(delay (tile-spec/process L4 spec-opts))))
+  (let [L8 (edn/read-string (slurp "data/tile-specs/L8.edn"))
+        L7 (edn/read-string (slurp "data/tile-specs/L7.edn"))
+        L5 (edn/read-string (slurp "data/tile-specs/L5.edn"))
+        L4 (edn/read-string (slurp "data/tile-specs/L4.edn"))]
+    (map tile-spec/insert (concat L8 L7 L5 L4))))

--- a/dev/seed.clj
+++ b/dev/seed.clj
@@ -1,0 +1,28 @@
+(ns seed
+  "Provide recipes for seeding Cassandra (and Elasticsearch) with real-world
+   congruent data."
+  (:require [lcmap.aardvark.tile-spec :as tile-spec]))
+
+(comment
+  "This will create tile-specs from real-world data that match what
+   is seen production systems. The test data was created when the
+   input format was not completely decided. Because this uses real
+   data, it can take some time to download."
+  (let [spec-opts {:data_shape [100 100]
+                   :name "conus"}
+        L8 {:id "LC80410282013101-SC20161214141315"
+            :checksum "482333697999739445f2b10ac39b709d"
+            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12142016-124335-732/LC80410282013101-SC20161214141315.tar.gz"}
+        L7 {:id "LE070410282000138-SC20161230023316"
+            :checksum "b6a2c24eed48101546a2c178d64e3af5"
+            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204133-305/LE070410282000138-SC20161230023316.tar.gz"}
+        L5 {:id "LT050410281984118-SC20170103075240"
+            :checksum "b4f5e1245dcd8078d9981395bace8060"
+            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204932-763/LT050410281984118-SC20170103075240.tar.gz"}
+        L4 {:id "LT040410281982328-SC20170103075212"
+            :checksum "d65532771a5234176ebd125466e206ff"
+            :uri "https://edclpdsftp.cr.usgs.gov/downloads/lcmap/sites/washington/./clay.austin.ctr@usgs.gov-12272016-204932-763/LT040410281982328-SC20170103075212.tar.gz"}]
+    @(delay (tile-spec/process L8 spec-opts))
+    @(delay (tile-spec/process L7 spec-opts))
+    @(delay (tile-spec/process L5 spec-opts))
+    @(delay (tile-spec/process L4 spec-opts))))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,41 +1,12 @@
 (ns user
   (:require
-   [cheshire.core :as json]
    [clojure.tools.namespace.repl :refer [refresh refresh-all]]
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [mount.core :as mount]
-   [lcmap.aardvark.config :as config]
    [lcmap.aardvark.server :as server]
    [lcmap.aardvark.worker :as worker]
-   [uberconf.core :as uberconf]
-   [lcmap.aardvark.tile-spec :as tile-spec]
-   [lcmap.aardvark.tile :as tile]
    [clojure.java.io :as io]))
-
-(def L5 {:id  "LT50460272000005"
-         :uri (-> "ESPA/CONUS/ARD/LT50460272000005-SC20160826121722.tar.gz" io/resource io/as-url str)
-         :checksum "9aa16eac2b9b8a20301ad091ceb9f3f4"})
-
-(def L7 {:id  "LE70460272000029"
-         :uri (-> "ESPA/CONUS/ARD/LE70460272000029-SC20160826120223.tar.gz" io/resource io/as-url str)
-         :checksum "e1d2f9b28b1f55c13ee2a4b7c4fc52e7"})
-
-(def tile-spec-opts {:data_shape [128 128]
-                     :name "conus"})
-
-(defn load-tile-spec []
-  (tile-spec/process L5 tile-spec-opts)
-  (tile-spec/process L7 tile-spec-opts))
-
-(defn dump-tile-spec [path]
-  (let [sorted (map (fn [kvs] (into (sorted-map) kvs)) (tile-spec/all))
-        output (json/generate-string {:pretty true})]
-    (spit path output)))
-
-(defn load-tiles []
-  (tile/process L5)
-  (tile/process L7))
 
 (defn start
   "Start dev system with a replacement config namespace"

--- a/test/lcmap/aardvark/server_test.clj
+++ b/test/lcmap/aardvark/server_test.clj
@@ -45,13 +45,6 @@
 
 (deftest landsat-tile-spec-resource
   (with-system
-    (testing "put a tile-spec as JSON"
-      (let [tile-spec (slurp (io/resource "data/sample-tile-spec.json"))
-            resp (req :put "http://localhost:5679/landsat/tile-spec/LANDSAT_5/TM/sr_band1"
-                      :headers {"Content-Type" "application/json"
-                                "Accept" "application/json"}
-                      :body tile-spec)]
-        (is (= 202 (:status resp)))))
     (testing "get an existing tile-spec"
       (let [resp (req :get "http://localhost:5679/landsat/tile-spec/LANDSAT_5/TM/sr_band1"
                       :headers {"Accept" "application/json"})]
@@ -60,7 +53,16 @@
       (let [resp (req :get "http://localhost:5679/landsat/tile-spec/LANDSAT_5/TM/marklar"
                       :headers {"Accept" "application/json"})]
         (is (= 404 (:status resp)))))
-    (testing "post multiple tile-specs"
+    ;; Disabled pending authorization and authentication.
+    #_(testing "put a tile-spec as JSON"
+      (let [tile-spec (slurp (io/resource "data/sample-tile-spec.json"))
+            resp (req :put "http://localhost:5679/landsat/tile-spec/LANDSAT_5/TM/sr_band1"
+                      :headers {"Content-Type" "application/json"
+                                "Accept" "application/json"}
+                      :body tile-spec)]
+        (is (= 202 (:status resp)))))
+    ;; Disabled pending authorization and authentication.
+    #_(testing "post multiple tile-specs"
       (let [tile-specs (slurp (io/resource "data/sample-tile-specs.json"))
             resp (req :post "http://localhost:5679/landsat/tile-spec"
                       :headers {"Content-Type" "application/json"


### PR DESCRIPTION
Requires an update to lcamp-test-data submodule. This submodule, although used for test, can also be used to bootstrap a system that uses data that conforms to the USGS ARD CONUS specifications.